### PR TITLE
Adds documentation for onactivate hook.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,6 +92,13 @@ $(".slideshow").swipeshow({
 });
 ```
 
+The ```onactivate``` hook is called when you first initialize swipeshow, and again each time a swipe event occurs. The method receives the following arguments:
+
+  * current slide (DOM object)
+  * current slide index
+  * previous slide (DOM object)
+  * previous slide index
+
 Next/previous buttons
 ---------------------
 


### PR DESCRIPTION
Had to dig through the code a bit to figure out that `onactivate` is called after each swipe event. Adding a line to the documentation to save others the hassle.
