### PR TITLE
add `css` file to bower's `main` configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,10 @@
     "jquery": "*"
   },
   "license": "MIT",
-  "main": "jquery.swipeshow.js",
+  "main": [
+    "jquery.swipeshow.js",
+    "jquery.swipeshow.css"
+  ],
   "scripts": [
     "jquery.swipeshow.js"
   ],


### PR DESCRIPTION
This will allow grunt tasks to identify the critical files in the library, and extract them.

For example, [grunt-bower-task](https://www.npmjs.org/package/grunt-bower-task) only copies out files that are referenced in the `main` parameter.
