### PR TITLE
Update jquery.swipeshow.js

### DIFF
--- a/jquery.swipeshow.js
+++ b/jquery.swipeshow.js
@@ -504,8 +504,6 @@
         // Switch to that slide.
         c.goTo(index);
 
-        e.preventDefault();
-
         // Restart the slideshow if it was already started before.
         if (start.started) c.start();
 


### PR DESCRIPTION
This final blanket preventDefault seems to needlessly prevent the browser from emulating mouse events, which allow common Mouse-related binding to work on touchscreen.  This meant that no Mouse-related bindings (for instance clicks) within swipeshow content would fire on touchscreen devices.